### PR TITLE
Update light dark code

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -108,39 +108,111 @@ lock_img_inline = HTML('<picture><source media="(prefers-color-scheme: light)" s
 open_lock_img_inline = HTML('<picture><source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open.svg"/><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open-dark.svg"/><img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open.svg" height="15"/></picture>')
 
 # a closed book: used to represent a journal
-book_img = tagList(
-  img(src = "https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book.svg#gh-light-mode-only", height = "15"),
-  img(src = "https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-dark.svg#gh-dark-mode-only", height = "15")
+book_img = withTags(
+  picture(
+    source(
+      media = "(prefers-color-scheme: light)",
+      srcset = "https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book.svg"
+    ),
+    source(
+      media = "(prefers-color-scheme: dark)",
+      srcset = "https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-dark.svg"
+    ),
+    img(
+      src = "https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book.svg", 
+      height = "15"
+    )
+  )
 )
 
 # an open book: used to represent an abstract
-book_reader_img = tagList(
-  img(src = "https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg#gh-light-mode-only", height = "15"),
-  img(src = "https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader-dark.svg#gh-dark-mode-only", height = "15")
+book_reader_img = withTags(
+  picture(
+    source(
+      media = "(prefers-color-scheme: light)",
+      srcset = "https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg"
+    ),
+    source(
+      media = "(prefers-color-scheme: dark)",
+      srcset = "https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader-dark.svg"
+    ),
+    img(
+      src = "https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg", 
+      height = "15"
+    )
+  )
 )
 
 # code icon: used to represent locations of archived/open source code/data
-code_img = tagList(
-  img(src = "https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code.svg#gh-light-mode-only", height = "15"),
-  img(src = "https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code-dark.svg#gh-dark-mode-only", height = "15")
+code_img = withTags(
+  picture(
+    source(
+      media = "(prefers-color-scheme: light)",
+      srcset = "https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code.svg"
+    ),
+    source(
+      media = "(prefers-color-scheme: dark)",
+      srcset = "https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code-dark.svg"
+    ),
+    img(
+      src = "https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code.svg", 
+      height = "15"
+    )
+  )
 )
 
 # users icon: used to represent author list
-users_img = tagList(
-  img(src = "https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users.svg#gh-light-mode-only", height = "15"),
-  img(src = "https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users-dark.svg#gh-dark-mode-only", height = "15")
+users_img = withTags(
+  picture(
+    source(
+      media = "(prefers-color-scheme: light)",
+      srcset = "https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users.svg"
+    ),
+    source(
+      media = "(prefers-color-scheme: dark)",
+      srcset = "https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users-dark.svg"
+    ),
+    img(
+      src = "https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users.svg", 
+      height = "15"
+    )
+  )
 )
 
 # quote icon: used to represent how to cite
-quote_img = tagList(
-  img(src = "https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/quote-left.svg#gh-light-mode-only", height = "15"),
-  img(src = "https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/quote-left-dark.svg#gh-dark-mode-only", height = "15")
+quote_img = withTags(
+  picture(
+    source(
+      media = "(prefers-color-scheme: light)",
+      srcset = "https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/quote.svg"
+    ),
+    source(
+      media = "(prefers-color-scheme: dark)",
+      srcset = "https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/quote-dark.svg"
+    ),
+    img(
+      src = "https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/quote.svg", 
+      height = "15"
+    )
+  )
 )
 
 # comment icon: used to represent citations
-comment_img = tagList(
-  img(src = "https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment.svg#gh-light-mode-only", height = "15"),
-  img(src = "https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment-dark.svg#gh-dark-mode-only", height = "15")
+comment_img = withTags(
+  picture(
+    source(
+      media = "(prefers-color-scheme: light)",
+      srcset = "https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment.svg"
+    ),
+    source(
+      media = "(prefers-color-scheme: dark)",
+      srcset = "https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment-dark.svg"
+    ),
+    img(
+      src = "https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment.svg", 
+      height = "15"
+    )
+  )
 )
 ```
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -13,6 +13,7 @@ params:
     value: TRUE
   do_2022_article_details:
     value: TRUE
+always_allow_html: TRUE
 ---
 
 ```{r setup, include=FALSE}
@@ -773,6 +774,81 @@ article_details(
   code_doi = NULL
 )
 ```
+
+## Citations
+
+```{r}
+bib_df = as.data.frame(bib)
+bib_df = data.frame(year = bib_df[,c("year")], key = rownames(bib_df))
+bib_df = bib_df[order(bib_df$year),]
+cite_counts = t(sapply(bib_df$key, function(key) {out = prep_bibentry(key); c(cross_ref = out$cites_crossref, gscholar = out$cites_gscholar)}))
+bib_df = cbind(bib_df, cite_counts)
+bib_df[is.na(bib_df)] = 0
+bib_df$year = as.numeric(bib_df$year)
+bib_df$year = factor(bib_df$year, levels = min(bib_df$year):max(bib_df$year))
+
+cites_table = function(df) {
+  tab = cbind(
+    Year = levels(df$year), 
+    Articles = tapply(df$year, df$year, length),
+    CrossRef = tapply(df$cross_ref, df$year, sum),
+    "Google Scholar" = tapply(df$gscholar, df$year, sum)
+  ); rownames(tab) = NULL
+  
+  tab[is.na(tab)] = 0
+  
+  tab = rbind(tab, c(Year = "All", 
+                     Articles = sum(as.numeric(tab[,"Articles"])), 
+                     CrossRef = sum(as.numeric(tab[,"CrossRef"])),
+                     "Google Scholar" = sum(as.numeric(tab[,"Google Scholar"]))))
+  
+  kableExtra::kbl(tab, "html", row.names = FALSE, align = "lccc") |>
+    kableExtra::kable_styling(full_width = FALSE) |>
+    kableExtra::add_header_above(c("Published" = 2, "Cumulative Citations" = 2)) |>
+    kableExtra::column_spec(1, bold = TRUE) |> 
+    kableExtra::row_spec(nrow(tab), bold = TRUE)
+}
+
+h_index = function(cite_counts) {
+  possible_h = 1:length(cite_counts)
+  max(possible_h[which(sapply(possible_h, function(h) sum(cite_counts >= h) >= h))])
+}
+
+h_index_table = function(df) {
+  h_cr = h_index(df$cross_ref)
+  h_gs = h_index(df$gscholar)
+  data.frame(type = c("CrossRef", "Google Scholar"), h = c(h_cr, h_gs)) |>
+    kableExtra::kbl("html", col.names = c(" ", "h-index")) |> 
+    kableExtra::column_spec(1, bold = TRUE)
+}
+```
+
+_This section contains summaries of citations made on research articles I've (co)authored; Google Scholar includes citations made in grey literature (e.g., agency reports) as well as from the peer-reviewed literature, whereas CrossRef indexes the latter only. Citation numbers differ here from those presented on [Google Scholar](https://scholar.google.com/citations?user=kembVusAAAAJ&hl=en) because those counts also include citations of grey literature I've (co)authored._
+
+### Lead Author Articles
+
+<details>
+ <summary>Click to View</summary>
+
+```{r}
+my_bib_df = bib_df[stringr::str_detect(bib_df$key, "^staton"),]
+cites_table(my_bib_df)
+h_index_table(my_bib_df)
+```
+
+</details>
+
+### All Articles
+
+<details>
+ <summary>Click to View</summary>
+
+```{r}
+cites_table(bib_df)
+h_index_table(bib_df)
+```
+
+</details>
 
 ```{r footnote}
 p(

--- a/README.Rmd
+++ b/README.Rmd
@@ -67,20 +67,45 @@ em_words = c(
 # note how each img has two options: one for each light and dark themes
 
 # a closed lock: used for denoting paywall articles/private repos
-lock_img = tagList(
-  img(src = "https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock.svg#gh-light-mode-only", height = "15"),
-  img(src = "https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-dark.svg#gh-dark-mode-only", height = "15")
+lock_img = withTags(
+  picture(
+    source(
+      media = "(prefers-color-scheme: light)",
+      srcset = "https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock.svg"
+    ),
+    source(
+      media = "(prefers-color-scheme: dark)",
+      srcset = "https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-dark.svg"
+    ),
+    img(
+      src = "https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock.svg", 
+      height = "15"
+    )
+  )
 )
 
 # an open lock: used for denoting open-access articles/public repos
-open_lock_img = tagList(
-  img(src = "https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open.svg#gh-light-mode-only", height = "15"),
-  img(src = "https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open-dark.svg#gh-dark-mode-only", height = "15")
+open_lock_img = withTags(
+  picture(
+    source(
+      media = "(prefers-color-scheme: light)",
+      srcset = "https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open.svg"
+    ),
+    source(
+      media = "(prefers-color-scheme: dark)",
+      srcset = "https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open-dark.svg"
+    ),
+    img(
+      src = "https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open.svg", 
+      height = "15"
+    )
+  )
 )
 
 # inline versions of these lock icons
-lock_img_inline = HTML("<img src=https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock.svg#gh-light-mode-only height=15/><img src=https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-dark.svg#gh-dark-mode-only height=15/>")
-open_lock_img_inline = HTML("<img src=https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open.svg#gh-light-mode-only height=15/><img src=https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open-dark.svg#gh-dark-mode-only height=15/>")
+lock_img_inline = HTML('<picture><source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock.svg"/><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-dark.svg"/><img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock.svg" height="15"/></picture>')
+
+open_lock_img_inline = HTML('<picture><source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open.svg"/><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open-dark.svg"/><img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open.svg" height="15"/></picture>')
 
 # a closed book: used to represent a journal
 book_img = tagList(

--- a/README.Rmd
+++ b/README.Rmd
@@ -18,7 +18,6 @@ params:
 ```{r setup, include=FALSE}
 knitr::opts_chunk$set(echo = FALSE, warning = FALSE, message = FALSE)
 library(htmltools)
-library(magrittr)
 ```
 
 ```{r load-bib}
@@ -468,9 +467,9 @@ my_em = function(x) {
 }
 
 my_name_strong = function(x) {
-  stringr::str_replace(x, "B. A. Staton", "<strong>B. A. Staton</strong>") %>%
-    stringr::str_replace("Staton, B. A,", "<strong>Staton, B. A,</strong>") %>%
-    stringr::str_replace("Staton, B,", "<strong>Staton, B,</strong>") %>%
+  stringr::str_replace(x, "B. A. Staton", "<strong>B. A. Staton</strong>") |>
+    stringr::str_replace("Staton, B. A,", "<strong>Staton, B. A,</strong>") |>
+    stringr::str_replace("Staton, B,", "<strong>Staton, B,</strong>") |>
     stringr::str_replace("B. Staton", "<strong>B. Staton</strong>")
 }
 
@@ -489,17 +488,17 @@ prep_bibentry = function(key) {
   str_bib = stringr::str_remove_all(str_bib, "_")
   
   # extract author list: do it this way so first and middle names are abbreviated
-  authors = stringr::str_extract(str_bib, "^.+\\([:digit:]") %>%
+  authors = stringr::str_extract(str_bib, "^.+\\([:digit:]") |>
     stringr::str_remove(" \\([:digit:]")
   
   # extract the title: do it this way so capitalization and {} are handled properly
-  # title = stringr::str_extract(str_bib, "“.+”") %>%
+  # title = stringr::str_extract(str_bib, "“.+”") |>
   #   substr(2, nchar(.)-1)
-  title = stringr::str_extract(str_bib, "\\). .+In\\:") %>%
-    stringr::str_remove("\\). ") %>%
-    stringr::str_remove(" In\\:$") %>%
-    substr(2,nchar(.)-2)
-  
+  title = stringr::str_extract(str_bib, "\\). .+In\\:") |>
+    stringr::str_remove("\\). ") |>
+    stringr::str_remove(" In\\:$")
+  title = substr(title, 2, nchar(title) - 2)
+
   # extract the abstract from online
   # abstract = tryCatch(rcrossref::cr_abstract(this_bib$doi), error = function(e) "Abstract not found on CrossRef. Consult the DOI link shown above for the abstract.")
   abstract = this_bib$abstract

--- a/README.md
+++ b/README.md
@@ -25,18 +25,15 @@
 
 ## My Interests
 
--   **Population dynamics** and models that describe them
--   **Methods for counting animals** (generally :fish:) and the models
-    we use to make sense of the data
--   **Bayesian analysis** as a means to quantify knowledge and
-    uncertainty
--   **State-space models** as a means to disentangle biological and
-    observational processes
--   **Transparent and data-driven decision processes** because
-    regardless of the outcome, it should always be clear why a choice
-    was made
--   **Reproducible workflows** because analyses are rarely ever
-    "finished"
+- **Population dynamics** and models that describe them
+- **Methods for counting animals** (generally :fish:) and the models we
+  use to make sense of the data
+- **Bayesian analysis** as a means to quantify knowledge and uncertainty
+- **State-space models** as a means to disentangle biological and
+  observational processes
+- **Transparent and data-driven decision processes** because regardless
+  of the outcome, it should always be clear why a choice was made
+- **Reproducible workflows** because analyses are rarely ever "finished"
 
 For more information about me and the things I work on, you can view my
 [curriculum
@@ -92,79 +89,89 @@ details.
 ## Current Projects
 
 <p>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open.svg" height="15"/>
+</picture>
 <em>and</em>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock.svg" height="15"/>
+</picture>
 <em>denote public and private repositories, respectively.</em>
 </p>
 
 #### Research
 
--   [GR-sslcm](https://github.com/bstaton1/GR-sslcm)
-    <img src=https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock.svg#gh-light-mode-only height=15/><img src=https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-dark.svg#gh-dark-mode-only height=15/>:
-    Development of a state-space life cycle model for spring Chinook
-    salmon in the Grande Ronde River basin of northeastern Oregon.
-    *Under active development*.
--   [LKG-RRS-ms-analysis]()
-    <img src=https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock.svg#gh-light-mode-only height=15/><img src=https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-dark.svg#gh-dark-mode-only height=15/>:
-    Analysis for a manuscript that compares the reproductive success
-    (i.e., number of progeny that survive to various stages) of
-    wild-spawning spring Chinook salmon that differ in a range of
-    characteristics including origin, sex, arrival timing, and size.
-    *Under active development*.
--   [inseason-voi-ms-analysis](https://github.com/bstaton1/inseason-voi-ms-analysis)
-    <img src=https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock.svg#gh-light-mode-only height=15/><img src=https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-dark.svg#gh-dark-mode-only height=15/>:
-    Analysis for a manuscript that investigates the Value of Information
-    of different data sources used during in-season decision-making
-    regarding total allowable harvest for large in-river subsistence
-    salmon fisheries. *Under active development*.
--   In-season estimation and prediction of effort and harvest for lower
-    Kuskokwim River subsistence salmon fisheries
-    -   [KuskoHarvEst](https://github.com/bstaton1/KuskoHarvEst)
-        <img src=https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open.svg#gh-light-mode-only height=15/><img src=https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open-dark.svg#gh-dark-mode-only height=15/>:
-        R package containing tools and an associated workflow for
-        estimating effort and harvest given monitoring data as inputs.
-        Tools can be executed via code-only or interactive
-        (point-and-click) workflows; the interactive workflow automates
-        summary report generation using
-        [Rmarkdown](https://rmarkdown.rstudio.com/) and built-in
-        templates. *Development considered complete at present*.
-    -   [KuskoHarvData](https://github.com/bstaton1/KuskoHarvData)
-        <img src=https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open.svg#gh-light-mode-only height=15/><img src=https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open-dark.svg#gh-dark-mode-only height=15/>:
-        R package containing historical data and estimates derived using
-        'KuskoHarvEst'. *Under active development*.
-    -   [KuskoHarvPred](https://github.com/bstaton1/KuskoHarvPred)
-        <img src=https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open.svg#gh-light-mode-only height=15/><img src=https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open-dark.svg#gh-dark-mode-only height=15/>:
-        R package containing tools for reproducibly conducting
-        regression analyses that seek to predict critical fishery
-        outcomes arising from proposed fishing opportunities. *Under
-        active development*.
+- [GR-sslcm](https://github.com/bstaton1/GR-sslcm)
+  <picture><source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock.svg"/><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-dark.svg"/><img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock.svg" height="15"/></picture>:
+  Development of a state-space life cycle model for spring Chinook
+  salmon in the Grande Ronde River basin of northeastern Oregon. *Under
+  active development*.
+- [LKG-RRS-ms-analysis]()
+  <picture><source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock.svg"/><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-dark.svg"/><img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock.svg" height="15"/></picture>:
+  Analysis for a manuscript that compares the reproductive success
+  (i.e., number of progeny that survive to various stages) of
+  wild-spawning spring Chinook salmon that differ in a range of
+  characteristics including origin, sex, arrival timing, and size.
+  *Under active development*.
+- [inseason-voi-ms-analysis](https://github.com/bstaton1/inseason-voi-ms-analysis)
+  <picture><source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock.svg"/><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-dark.svg"/><img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock.svg" height="15"/></picture>:
+  Analysis for a manuscript that investigates the Value of Information
+  of different data sources used during in-season decision-making
+  regarding total allowable harvest for large in-river subsistence
+  salmon fisheries. *Under active development*.
+- In-season estimation and prediction of effort and harvest for lower
+  Kuskokwim River subsistence salmon fisheries
+  - [KuskoHarvEst](https://github.com/bstaton1/KuskoHarvEst)
+    <picture><source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open.svg"/><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open-dark.svg"/><img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open.svg" height="15"/></picture>:
+    R package containing tools and an associated workflow for estimating
+    effort and harvest given monitoring data as inputs. Tools can be
+    executed via code-only or interactive (point-and-click) workflows;
+    the interactive workflow automates summary report generation using
+    [Rmarkdown](https://rmarkdown.rstudio.com/) and built-in templates.
+    *Development considered complete at present*.
+  - [KuskoHarvData](https://github.com/bstaton1/KuskoHarvData)
+    <picture><source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open.svg"/><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open-dark.svg"/><img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open.svg" height="15"/></picture>:
+    R package containing historical data and estimates derived using
+    'KuskoHarvEst'. *Under active development*.
+  - [KuskoHarvPred](https://github.com/bstaton1/KuskoHarvPred)
+    <picture><source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open.svg"/><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open-dark.svg"/><img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open.svg" height="15"/></picture>:
+    R package containing tools for reproducibly conducting regression
+    analyses that seek to predict critical fishery outcomes arising from
+    proposed fishing opportunities. *Under active development*.
 
 #### General Purpose R Packages
 
--   [postpack](https://github.com/bstaton1/postpack)
-    ([website](https://bstaton1.github.io/postpack/))
-    <img src=https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open.svg#gh-light-mode-only height=15/><img src=https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open-dark.svg#gh-dark-mode-only height=15/>:
-    Assortment of tools for working with R objects of class `mcmc.list`.
-    *Under active development*.
--   [msdown](https://github.com/bstaton1/msdown)
-    <img src=https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock.svg#gh-light-mode-only height=15/><img src=https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-dark.svg#gh-dark-mode-only height=15/>:
-    Template and utilities for writing clean, reproducible, and version
-    controllable manuscripts built off
-    [bookdown](https://pkgs.rstudio.com/bookdown). *Under active
-    development*.
+- [postpack](https://github.com/bstaton1/postpack)
+  ([website](https://bstaton1.github.io/postpack/))
+  <picture><source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open.svg"/><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open-dark.svg"/><img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open.svg" height="15"/></picture>:
+  Assortment of tools for working with R objects of class `mcmc.list`.
+  *Under active development*.
+- [msdown](https://github.com/bstaton1/msdown)
+  <picture><source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock.svg"/><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-dark.svg"/><img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock.svg" height="15"/></picture>:
+  Template and utilities for writing clean, reproducible, and version
+  controllable manuscripts built off
+  [bookdown](https://pkgs.rstudio.com/bookdown). *Under active
+  development*.
 
 ## Peer-Reviewed Journal Articles
 
 <p>
 <em>Click the title of each article to see more information.</em>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open.svg" height="15"/>
+</picture>
 <em>and</em>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock.svg" height="15"/>
+</picture>
 <em>denote open-access and paywall articles, respectively.</em>
 </p>
 
@@ -172,8 +179,11 @@ details.
 
 <details>
 <summary>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open.svg" height="15"/>
+</picture>
 <strong>Improved Productivity of Naturalized Spring Chinook Salmon Following Reintroduction From a Hatchery Stock in Lookingglass Creek, Oregon</strong>
 </summary>
 <p></p>
@@ -199,7 +209,7 @@ In Press
 <em>AUTHORS</em>
 </strong>
 <ul>
-<p>Nuetzel, H. M, P. F. Galbreath, <strong>B. A. Staton</strong>, C. A. Crump, L. M. Naylor, and G. E. Shippentower</p>
+<p>Nuetzel, H. M., P. F. Galbreath, <strong>B. A. Staton</strong>, C. A. Crump, L. M. Naylor, and G. E. Shippentower</p>
 </ul>
 <img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg#gh-light-mode-only" height="15"/>
 <img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader-dark.svg#gh-dark-mode-only" height="15"/>
@@ -241,8 +251,11 @@ In Press
 </details>
 <details>
 <summary>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock.svg" height="15"/>
+</picture>
 <strong>Thermal Performance of the Electron Transport Complex III in Seven Alabama Fishes</strong>
 </summary>
 <p></p>
@@ -268,7 +281,7 @@ In Press
 <em>AUTHORS</em>
 </strong>
 <ul>
-<p>Horne, L. M, D. R. DeVries, R. Wright, E. Irwin, <strong>B. A. Staton</strong>, H. A. Abdelrahman, and J. A. Stoeckel</p>
+<p>Horne, L. M., D. R. DeVries, R. Wright, E. Irwin, <strong>B. A. Staton</strong>, H. A. Abdelrahman, and J. A. Stoeckel</p>
 </ul>
 <img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg#gh-light-mode-only" height="15"/>
 <img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader-dark.svg#gh-dark-mode-only" height="15"/>
@@ -310,8 +323,11 @@ NA
 </details>
 <details>
 <summary>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock.svg" height="15"/>
+</picture>
 <strong>Chinook Salmon Diversity Contributes to Fishery Stability and Trade-Offs with Mixed-Stock Harvest</strong>
 </summary>
 <p></p>
@@ -337,7 +353,7 @@ NA
 <em>AUTHORS</em>
 </strong>
 <ul>
-<p>Connors, B. M, M. R. Siegle, J. Harding, S. Rossi, <strong>B. A. Staton</strong>, M. L. Jones, M. J. Bradford, R. Brown, B. Bechtol, B. Doherty, S. Cox, and B. J. G. Sutherland</p>
+<p>Connors, B. M., M. R. Siegle, J. Harding, S. Rossi, <strong>B. A. Staton</strong>, M. L. Jones, M. J. Bradford, R. Brown, B. Bechtol, B. Doherty, S. Cox, and B. J. G. Sutherland</p>
 </ul>
 <img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg#gh-light-mode-only" height="15"/>
 <img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader-dark.svg#gh-dark-mode-only" height="15"/>
@@ -369,18 +385,21 @@ NA
 </strong>
 <ul>
 <strong>Crossref: </strong>
-0
+2
 <br/>
 <strong>Google Scholar: </strong>
-NA
+2
 </ul>
 </ul>
 <hr/>
 </details>
 <details>
 <summary>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open.svg" height="15"/>
+</picture>
 <strong>Identification of Infectious Agents in Early Marine Chinook and Coho Salmon Associated with Cohort Survival</strong>
 </summary>
 <p></p>
@@ -406,7 +425,7 @@ NA
 <em>AUTHORS</em>
 </strong>
 <ul>
-<p>Bass, A. L, A. W. Bateman, B. M. Connors, <strong>B. A. Staton</strong>, E. B. Rondeau, G. J. Mordecai, A. K. Teffer, K. H. Kaukinen, S. Li, A. M. Tabata, D. A. Patterson, S. G. Hinch, and K. M. Miller</p>
+<p>Bass, A. L., A. W. Bateman, B. M. Connors, <strong>B. A. Staton</strong>, E. B. Rondeau, G. J. Mordecai, A. K. Teffer, K. H. Kaukinen, S. Li, A. M. Tabata, D. A. Patterson, S. G. Hinch, and K. M. Miller</p>
 </ul>
 <img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg#gh-light-mode-only" height="15"/>
 <img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader-dark.svg#gh-dark-mode-only" height="15"/>
@@ -436,18 +455,21 @@ Not Available
 </strong>
 <ul>
 <strong>Crossref: </strong>
-1
+7
 <br/>
 <strong>Google Scholar: </strong>
-1
+7
 </ul>
 </ul>
 <hr/>
 </details>
 <details>
 <summary>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock.svg" height="15"/>
+</picture>
 <strong>Accounting for Uncertainty When Estimating Drivers of Imperfect Detection: An Integrated Approach Illustrated with Snorkel Surveys for Riverine Fishes</strong>
 </summary>
 <p></p>
@@ -473,7 +495,7 @@ Not Available
 <em>AUTHORS</em>
 </strong>
 <ul>
-<p><strong>Staton, B. A,</strong> C. Justice, S. White, E. R. Sedell, L. A. Burns, and M. J. Kaylor</p>
+<p>Staton, B. A., C. Justice, S. White, E. R. Sedell, L. A. Burns, and M. J. Kaylor</p>
 </ul>
 <img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg#gh-light-mode-only" height="15"/>
 <img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader-dark.svg#gh-dark-mode-only" height="15"/>
@@ -505,10 +527,10 @@ Not Available
 </strong>
 <ul>
 <strong>Crossref: </strong>
-2
+3
 <br/>
 <strong>Google Scholar: </strong>
-1
+3
 </ul>
 </ul>
 <hr/>
@@ -518,8 +540,11 @@ Not Available
 
 <details>
 <summary>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open.svg" height="15"/>
+</picture>
 <strong>Precocious Maturation of Hatchery-Raised Spring Chinook Salmon as Age-2 Minijacks Is Not Detectably Affected by Sire Age</strong>
 </summary>
 <p></p>
@@ -545,7 +570,7 @@ Not Available
 <em>AUTHORS</em>
 </strong>
 <ul>
-<p>Galbreath, P. F, <strong>B. A. Staton</strong>, H. M. Nuetzel, C. A. Stockton, C. M. Knudsen, L. R. Medeiros, I. J. Koch, W. J. Bosch, and A. L. Pierce</p>
+<p>Galbreath, P. F., <strong>B. A. Staton</strong>, H. M. Nuetzel, C. A. Stockton, C. M. Knudsen, L. R. Medeiros, I. J. Koch, W. J. Bosch, and A. L. Pierce</p>
 </ul>
 <img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg#gh-light-mode-only" height="15"/>
 <img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader-dark.svg#gh-dark-mode-only" height="15"/>
@@ -577,18 +602,21 @@ Not Available
 </strong>
 <ul>
 <strong>Crossref: </strong>
-0
+2
 <br/>
 <strong>Google Scholar: </strong>
-0
+2
 </ul>
 </ul>
 <hr/>
 </details>
 <details>
 <summary>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock.svg" height="15"/>
+</picture>
 <strong>Incorporating Demographic Information into Spawner&#8211;Recruit Analyses Alters Biological Reference Point Estimates for a Western Alaska Salmon Population</strong>
 </summary>
 <p></p>
@@ -614,7 +642,7 @@ Not Available
 <em>AUTHORS</em>
 </strong>
 <ul>
-<p><strong>Staton, B. A,</strong> M. J. Catalano, S. J. Fleischman, and J. Ohlberger</p>
+<p>Staton, B. A., M. J. Catalano, S. J. Fleischman, and J. Ohlberger</p>
 </ul>
 <img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg#gh-light-mode-only" height="15"/>
 <img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader-dark.svg#gh-dark-mode-only" height="15"/>
@@ -646,18 +674,21 @@ Not Available
 </strong>
 <ul>
 <strong>Crossref: </strong>
-3
+6
 <br/>
 <strong>Google Scholar: </strong>
-3
+8
 </ul>
 </ul>
 <hr/>
 </details>
 <details>
 <summary>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock.svg" height="15"/>
+</picture>
 <strong>Temperature, Emergence Phenology and Consumption Drive Seasonal Shifts in Fish Growth and Production across Riverscapes</strong>
 </summary>
 <p></p>
@@ -683,7 +714,7 @@ Not Available
 <em>AUTHORS</em>
 </strong>
 <ul>
-<p>Kaylor, M. J, C. Justice, J. B. Armstrong, <strong>B. A. Staton</strong>, L. A. Burns, E. Sedell, and S. M. White</p>
+<p>Kaylor, M. J., C. Justice, J. B. Armstrong, <strong>B. A. Staton</strong>, L. A. Burns, E. Sedell, and S. M. White</p>
 </ul>
 <img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg#gh-light-mode-only" height="15"/>
 <img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader-dark.svg#gh-dark-mode-only" height="15"/>
@@ -728,8 +759,11 @@ Not Available
 
 <details>
 <summary>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock.svg" height="15"/>
+</picture>
 <strong>Evaluation of Methods for Spawner&#8211;Recruit Analysis in Mixed-Stock Pacific Salmon Fisheries</strong>
 </summary>
 <p></p>
@@ -755,7 +789,7 @@ Not Available
 <em>AUTHORS</em>
 </strong>
 <ul>
-<p><strong>Staton, B. A,</strong> M. J. Catalano, B. M. Connors, L. G. C. Jr, M. L. Jones, C. J. Walters, S. J. Fleischman, and D. C. Gwinn</p>
+<p>Staton, B. A., M. J. Catalano, B. M. Connors, L. G. C. Jr, M. L. Jones, C. J. Walters, S. J. Fleischman, and D. C. Gwinn</p>
 </ul>
 <img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg#gh-light-mode-only" height="15"/>
 <img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader-dark.svg#gh-dark-mode-only" height="15"/>
@@ -787,18 +821,21 @@ Not Available
 </strong>
 <ul>
 <strong>Crossref: </strong>
-7
+8
 <br/>
 <strong>Google Scholar: </strong>
-7
+8
 </ul>
 </ul>
 <hr/>
 </details>
 <details>
 <summary>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock.svg" height="15"/>
+</picture>
 <strong>Incorporating Harvest&#8211;Population Diversity Trade-Offs into Harvest Policy Analyses of Salmon Management in Large River Basins</strong>
 </summary>
 <p></p>
@@ -824,7 +861,7 @@ Not Available
 <em>AUTHORS</em>
 </strong>
 <ul>
-<p>Connors, B. M, <strong>B. Staton</strong>, L. Coggins, C. Walters, M. Jones, D. Gwinn, M. Catalano, and S. Fleischman</p>
+<p>Connors, B. M., <strong>B. Staton</strong>, L. Coggins, C. Walters, M. Jones, D. Gwinn, M. Catalano, and S. Fleischman</p>
 </ul>
 <img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg#gh-light-mode-only" height="15"/>
 <img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader-dark.svg#gh-dark-mode-only" height="15"/>
@@ -856,10 +893,10 @@ Not Available
 </strong>
 <ul>
 <strong>Crossref: </strong>
-10
+11
 <br/>
 <strong>Google Scholar: </strong>
-12
+13
 </ul>
 </ul>
 <hr/>
@@ -869,8 +906,11 @@ Not Available
 
 <details>
 <summary>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock.svg" height="15"/>
+</picture>
 <strong>Bayesian Information Updating Procedures for Pacific Salmon Run Size Indicators: Evaluation in the Presence and Absence of Auxiliary Migration Timing Information</strong>
 </summary>
 <p></p>
@@ -931,15 +971,18 @@ Not Available
 4
 <br/>
 <strong>Google Scholar: </strong>
-6
+9
 </ul>
 </ul>
 <hr/>
 </details>
 <details>
 <summary>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open.svg" height="15"/>
+</picture>
 <strong>Migratory Timing and Rates of Chinook Salmon Bound for the Kwethluk and Kisaralik Rivers</strong>
 </summary>
 <p></p>
@@ -965,7 +1008,7 @@ Not Available
 <em>AUTHORS</em>
 </strong>
 <ul>
-<p>Moses, A. P, <strong>B. A. Staton</strong>, and N. J. Smith</p>
+<p>Moses, A. P., <strong>B. A. Staton</strong>, and N. J. Smith</p>
 </ul>
 <img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg#gh-light-mode-only" height="15"/>
 <img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader-dark.svg#gh-dark-mode-only" height="15"/>
@@ -1010,8 +1053,11 @@ Not Available
 
 <details>
 <summary>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock.svg" height="15"/>
+</picture>
 <strong>Development and Evaluation of a Migration Timing Forecast Model for Kuskokwim River Chinook Salmon</strong>
 </summary>
 <p></p>
@@ -1037,7 +1083,7 @@ Not Available
 <em>AUTHORS</em>
 </strong>
 <ul>
-<p><strong>Staton, B. A,</strong> M. J. Catalano, T. M. Farmer, A. Abebe, and F. S. Dobson</p>
+<p>Staton, B. A., M. J. Catalano, T. M. Farmer, A. Abebe, and F. S. Dobson</p>
 </ul>
 <img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg#gh-light-mode-only" height="15"/>
 <img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader-dark.svg#gh-dark-mode-only" height="15"/>
@@ -1070,15 +1116,18 @@ Not Available
 5
 <br/>
 <strong>Google Scholar: </strong>
-8
+9
 </ul>
 </ul>
 <hr/>
 </details>
 <details>
 <summary>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock.svg" height="15"/>
+</picture>
 <strong>Maximize Your Meeting: A Student's Guide to AFS Meetings</strong>
 </summary>
 <p></p>
@@ -1104,7 +1153,7 @@ Not Available
 <em>AUTHORS</em>
 </strong>
 <ul>
-<p>Dippold, D. A, G. D. Adams, T. M. Farmer, and <strong>B. A. Staton</strong></p>
+<p>Dippold, D. A., G. D. Adams, T. M. Farmer, and <strong>B. A. Staton</strong></p>
 </ul>
 <img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg#gh-light-mode-only" height="15"/>
 <img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader-dark.svg#gh-dark-mode-only" height="15"/>
@@ -1144,8 +1193,11 @@ Not Available
 </details>
 <details>
 <summary>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-open.svg" height="15"/>
+</picture>
 <strong>Physiological Ecology of Four Endemic Alabama Species and the Exotic Asiatic Weatherfish, <em>Misgurnus Anguillicaudatus</em> (Cantor, 1842)</strong>
 </summary>
 <p></p>
@@ -1168,7 +1220,7 @@ Not Available
 <em>AUTHORS</em>
 </strong>
 <ul>
-<p>White, L, M. Meade, and <strong>B. Staton</strong></p>
+<p>White, L., M. Meade, and <strong>B. Staton</strong></p>
 </ul>
 <img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg#gh-light-mode-only" height="15"/>
 <img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader-dark.svg#gh-dark-mode-only" height="15"/>
@@ -1208,8 +1260,11 @@ NA
 </details>
 <details>
 <summary>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/lock.svg" height="15"/>
+</picture>
 <strong>From Sequential to Integrated Bayesian Analyses: Exploring the Continuum with a Pacific Salmon Spawner-Recruit Model</strong>
 </summary>
 <p></p>
@@ -1235,7 +1290,7 @@ NA
 <em>AUTHORS</em>
 </strong>
 <ul>
-<p><strong>Staton, B. A,</strong> M. J. Catalano, and S. J. Fleischman</p>
+<p>Staton, B. A., M. J. Catalano, and S. J. Fleischman</p>
 </ul>
 <img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg#gh-light-mode-only" height="15"/>
 <img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader-dark.svg#gh-dark-mode-only" height="15"/>
@@ -1268,7 +1323,7 @@ Not Available
 10
 <br/>
 <strong>Google Scholar: </strong>
-19
+20
 </ul>
 </ul>
 <hr/>
@@ -1307,7 +1362,7 @@ Ben Staton under the
 <sup>
 <em>
 Updated
-2022-12-01
+2023-06-28
 </em>
 </sup>
 </sub>

--- a/README.md
+++ b/README.md
@@ -188,8 +188,11 @@ details.
 </summary>
 <p></p>
 <ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book.svg" height="15"/>
+</picture>
 <strong>
 <em>JOURNAL</em>
 </strong>
@@ -203,24 +206,33 @@ In Press
 </a>
 </p>
 </ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users.svg" height="15"/>
+</picture>
 <strong>
 <em>AUTHORS</em>
 </strong>
 <ul>
 <p>Nuetzel, H. M., P. F. Galbreath, <strong>B. A. Staton</strong>, C. A. Crump, L. M. Naylor, and G. E. Shippentower</p>
 </ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg" height="15"/>
+</picture>
 <strong>
 <em>ABSTRACT</em>
 </strong>
 <ul>
 <p align="justify">Supplementation of depressed salmonid populations with hatchery production has been questioned due to domestication effects, which may reduce reproductive fitness. However, for extirpated populations, reintroduction typically requires use of hatchery stocks. We evaluated this strategy by monitoring the naturalization of spring Chinook salmon reintroduced to Lookingglass Creek, OR (Grande Ronde Basin) from a captive brood, hatchery stock. We compared the reproductive success (RS) of naturally spawning natural-origin (NOR) relative to hatchery-origin (HOR) adults across nine brood years. Individual RS (the number of progeny produced) was estimated by pedigree reconstruction analyses, and then analyzed by generalized linear models to estimate the effect of parental origin, while controlling for potentially confounding covariates. When evaluating RS by juvenile progeny, NOR spawners were more likely to be reproductively successful, and when successful, produced more progeny on average than successful HOR counterparts. We found a similar advantage when evaluating RS by adult progeny, although the origin effect was not as important among successful spawners. Results suggest fish reintroduced from a hatchery stock possess the adaptive capacity to positively contribute to natural productivity and recovery goals.</p>
 </ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code.svg" height="15"/>
+</picture>
 <strong>
 <em>CODE/DATA</em>
 </strong>
@@ -234,8 +246,11 @@ In Press
 </a>
 </ul>
 <p></p>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment.svg" height="15"/>
+</picture>
 <strong>
 <em>CITATIONS</em>
 </strong>
@@ -260,8 +275,11 @@ In Press
 </summary>
 <p></p>
 <ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book.svg" height="15"/>
+</picture>
 <strong>
 <em>JOURNAL</em>
 </strong>
@@ -275,24 +293,33 @@ In Press
 </a>
 </p>
 </ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users.svg" height="15"/>
+</picture>
 <strong>
 <em>AUTHORS</em>
 </strong>
 <ul>
 <p>Horne, L. M., D. R. DeVries, R. Wright, E. Irwin, <strong>B. A. Staton</strong>, H. A. Abdelrahman, and J. A. Stoeckel</p>
 </ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg" height="15"/>
+</picture>
 <strong>
 <em>ABSTRACT</em>
 </strong>
 <ul>
 <p align="justify">Management of fish populations for conservation in thermally variable systems requires an understanding of the fish's underlying physiology and responses to thermal stress. Physiological research at the organismal level provides information on the overall effects of stressors such as extreme temperature fluctuations. While experiments with whole organisms provide information as to the overall effects of temperature fluctuations, biochemical assays of thermal stress provide direct results of exposure that are both sensitive and specific. Electron transport system (ETS; Complex III) assays quantify a rate-limiting step of respiratory enzymes. Parameters that can be estimated via this approach include optimal thermal temperature (<em>T</em><sub>opt</sub>) and optimal breadth of thermal performance (<em>T</em><sub>breadth</sub>), which can both be related to organismal-level temperature thresholds. We exposed enzymes of seven fish species (native fish chosen to represent a typical community in Alabama streams) to temperatures in the range of 11-44&#176;C. The resultant enzymatic termal performance curves showed that <em>T</em><sub>opt</sub>, the lower temperature for enyzme optimal thermal performance (<em>T</em><sub>low</sub>), the upper temperature for enzyme optimal thermal performance (<em>T</em><sub>up</sub>), and <em>T</em><sub>breadth</sub> differed among species. Relationships between enzymatic activity and temperature for all fish followed a pattern of steadily increasing enzyme activity to <em>T</em><sub>opt</sub> before gradually decreasing with increasing temperature. A comparison of our enzyme optimum and upper-temperature limit results versus published critical thermal maxima values supports that ETS Complex III assays may be useful for assessing organismal-level thermal tolerance.</p>
 </ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code.svg" height="15"/>
+</picture>
 <strong>
 <em>CODE/DATA</em>
 </strong>
@@ -306,8 +333,11 @@ In Press
 </a>
 </ul>
 <p></p>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment.svg" height="15"/>
+</picture>
 <strong>
 <em>CITATIONS</em>
 </strong>
@@ -332,8 +362,11 @@ NA
 </summary>
 <p></p>
 <ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book.svg" height="15"/>
+</picture>
 <strong>
 <em>JOURNAL</em>
 </strong>
@@ -347,24 +380,33 @@ NA
 </a>
 </p>
 </ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users.svg" height="15"/>
+</picture>
 <strong>
 <em>AUTHORS</em>
 </strong>
 <ul>
 <p>Connors, B. M., M. R. Siegle, J. Harding, S. Rossi, <strong>B. A. Staton</strong>, M. L. Jones, M. J. Bradford, R. Brown, B. Bechtol, B. Doherty, S. Cox, and B. J. G. Sutherland</p>
 </ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg" height="15"/>
+</picture>
 <strong>
 <em>ABSTRACT</em>
 </strong>
 <ul>
 <p align="justify">Variation among populations in life history and intrinsic population characteristics (i.e., population diversity) helps maintain resilience to environmental change and dampen interannual variability in ecosystem services. As a result, ecological variation, and the processes that generate it, is considered central to strategies for managing risks to ecosystems in an increasingly variable and uncertain world. However, characterizing population diversity is difficult, particularly in large and remote regions, which often prevents its formal consideration in management advice. We combined genetic stock identification of archived scale and tissue samples with state-space run-reconstruction models to estimate migration timing and annual return abundance for eight geographically and genetically distinct Chinook salmon populations within the Canadian portion of the Yukon River. We found that among-population variation in migration timing and return abundances resulted in aggregate return migrations that were 2.1 times longer and 1.4 times more stable than if they had composed a single homogeneous population. We then fit state-space spawnerrecruitment models to the annual return abundances to characterize among-population diversity in intrinsic productivity and population size and their consequences for the fisheries they support. Productivity and carrying capacity varied among populations by approximately 2.4-fold (2.9 to 6.9 recruits per spawner) and three-fold (8800 to 27,000 spawners), respectively. This diversity implies an equilibrium trade-off between harvesting of the population aggregate and the conservation of individual populations whereby the harvest rate predicted to maximize aggregate harvests comes at the cost of overfishing 40% of the populations but with a relatively low risk of extirpating the weakest ones. Our findings illustrate how population diversity in one of the largest salmon-producing river basins in the world contributes to fishery stability and food security in a region where salmon have high cultural and subsistence value. More generally, our work demonstrates the utility of molecular analyses of archived biological material for characterizing diversity in biological systems and its benefits and consequences for trade-offs in decision-making.</p>
 </ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code.svg" height="15"/>
+</picture>
 <strong>
 <em>CODE/DATA</em>
 </strong>
@@ -378,8 +420,11 @@ NA
 </a>
 </ul>
 <p></p>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment.svg" height="15"/>
+</picture>
 <strong>
 <em>CITATIONS</em>
 </strong>
@@ -404,8 +449,11 @@ NA
 </summary>
 <p></p>
 <ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book.svg" height="15"/>
+</picture>
 <strong>
 <em>JOURNAL</em>
 </strong>
@@ -419,24 +467,33 @@ NA
 </a>
 </p>
 </ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users.svg" height="15"/>
+</picture>
 <strong>
 <em>AUTHORS</em>
 </strong>
 <ul>
 <p>Bass, A. L., A. W. Bateman, B. M. Connors, <strong>B. A. Staton</strong>, E. B. Rondeau, G. J. Mordecai, A. K. Teffer, K. H. Kaukinen, S. Li, A. M. Tabata, D. A. Patterson, S. G. Hinch, and K. M. Miller</p>
 </ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg" height="15"/>
+</picture>
 <strong>
 <em>ABSTRACT</em>
 </strong>
 <ul>
 <p align="justify">Recent decades have seen an increased appreciation for the role infectious diseases can play in mass mortality events across a diversity of marine taxa. At the same time many Pacific salmon populations have declined in abundance as a result of reduced marine survival. However, few studies have explicitly considered the potential role pathogens could play in these declines. Using a multi-year dataset spanning 59 pathogen taxa in Chinook and Coho salmon sampled along the British Columbia coast, we carried out an exploratory analysis to quantify evidence for associations between pathogen prevalence and cohort survival and between pathogen load and body condition. While a variety of pathogens had moderate to strong negative correlations with body condition or survival for one host species in one season, we found that <em>Tenacibaculum maritimum</em> and <em>Piscine orthoreovirus</em> had consistently negative associations with body condition in both host species and seasons and were negatively associated with survival for Chinook salmon collected in the fall and winter. Our analyses, which offer the most comprehensive examination of associations between pathogen prevalence and Pacific salmon survival to date, suggest that pathogens in Pacific salmon warrant further attention, especially those whose distribution and abundance may be influenced by anthropogenic stressors.</p>
 </ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code.svg" height="15"/>
+</picture>
 <strong>
 <em>CODE/DATA</em>
 </strong>
@@ -448,8 +505,11 @@ Not Available
 Not Available
 </ul>
 <p></p>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment.svg" height="15"/>
+</picture>
 <strong>
 <em>CITATIONS</em>
 </strong>
@@ -474,8 +534,11 @@ Not Available
 </summary>
 <p></p>
 <ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book.svg" height="15"/>
+</picture>
 <strong>
 <em>JOURNAL</em>
 </strong>
@@ -489,24 +552,33 @@ Not Available
 </a>
 </p>
 </ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users.svg" height="15"/>
+</picture>
 <strong>
 <em>AUTHORS</em>
 </strong>
 <ul>
 <p>Staton, B. A., C. Justice, S. White, E. R. Sedell, L. A. Burns, and M. J. Kaylor</p>
 </ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg" height="15"/>
+</picture>
 <strong>
 <em>ABSTRACT</em>
 </strong>
 <ul>
 <p align="justify">Imperfect detection is a common issue affecting the accuracy of surveys that quantify animal abundance and distribution. To quantify detectability, counts are often calibrated to independent measures of abundance (e.g., via mark-recapture) but stochastic sampling variability in both data types is not typically accounted for. This practice may cause detectability to be quantified inaccurately and lead to overly confident predictions for out-of-sample applications. Our objective was to develop, apply, and simulation-test an integrated approach for quantifying detectability that better-accommodates uncertainty in the data. The method assumes mark-recapture and count surveys sample the same local abundance with error, allowing the construction of a joint likelihood function for both data sets. The model estimates coefficients that link detection probability to local covariates through a logit-linear model, which enables correcting counts for imperfect detection in locations where mark-recapture data are unavailable. We illustrate the application of the model with an empirical data set of over 100 paired snorkel count and mark-recapture electrofishing surveys for riverine salmonids in northeastern Oregon. Covariates that best explained heterogeneity in detectability included species, visibility, and channel unit type and depth, though substantial variability was attributed to site-level random effects. Estimated detection probability ranged from 0.02 to 0.92 among surveys and was higher for Chinook Salmon (<em>Oncorhynchus tshawytscha</em>) juveniles (mean: 0.38) than for steelhead/Rainbow Trout (<em>O. mykiss</em>; mean: 0.24). Simulation analyses revealed that our integrated model performed better (relative to a method that treated mark-recapture abundance estimates as known without error) with respect to (i) selection of covariates, (ii) credible interval coverage, (iii) accuracy of estimated random variability terms, and (iv) reduced sensitivity to violated mark-recapture assumptions surrounding behavioral effects. This model represents an improvement over simpler calibration methods, particularly for snorkel surveys, by applying more a rigorous statistical treatment of sources of variability while explicitly describing the mechanistic link between local conditions and detectability. The analytical methods we illustrate are general and could be broadly applied to quantify detectability in other biological surveys with paired abundance and count data.</p>
 </ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code.svg" height="15"/>
+</picture>
 <strong>
 <em>CODE/DATA</em>
 </strong>
@@ -520,8 +592,11 @@ Not Available
 </a>
 </ul>
 <p></p>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment.svg" height="15"/>
+</picture>
 <strong>
 <em>CITATIONS</em>
 </strong>
@@ -549,8 +624,11 @@ Not Available
 </summary>
 <p></p>
 <ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book.svg" height="15"/>
+</picture>
 <strong>
 <em>JOURNAL</em>
 </strong>
@@ -564,24 +642,33 @@ Not Available
 </a>
 </p>
 </ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users.svg" height="15"/>
+</picture>
 <strong>
 <em>AUTHORS</em>
 </strong>
 <ul>
 <p>Galbreath, P. F., <strong>B. A. Staton</strong>, H. M. Nuetzel, C. A. Stockton, C. M. Knudsen, L. R. Medeiros, I. J. Koch, W. J. Bosch, and A. L. Pierce</p>
 </ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg" height="15"/>
+</picture>
 <strong>
 <em>ABSTRACT</em>
 </strong>
 <ul>
 <p align="justify">Juvenile males produced in spring Chinook Salmon <em>Oncorhynchus tshawytscha</em> hatchery programs can exhibit high rates of maturation in freshwater as 2-year-old "minijacks." This phenomenon is associated with high feeding rates and increased size and/or growth that juveniles experience in the hatchery environment, though studies also support a genetic component affecting age of maturation among salmonids, including precocious maturation in freshwater. This prompted a study to test whether the age of natural-origin spring Chinook Salmon broodstock affects the rate at which their hatchery-raised male progeny mature as age-2 minijacks. In three consecutive brood years, we factorially mated age-4 adult females with age-3, age-4, and age-5 adult (jacks) male broodstock. In the latter two brood years, we also incorporated age-1 precocious parr (microjacks) as sires. After communal rearing to the smolt stage (age-1), male juveniles were characterized as immature or as maturing minijacks based on plasma 11-ketotestosterone concentration, and each was identified to its respective full-sib progeny group via genetic parentage analysis. A generalized linear mixed model, performed for each brood year separately, was used to characterize expected precocious maturation rates by sire age, while controlling for potential effects of smolt body weight and individual parent identities. Multiple comparisons across sire ages within brood years were used to evaluate relative rates of precocious maturation. Estimates of the probability of minijack maturation among families within sire ages and brood years varied from as much as 0% to 100%, and no consistent effect of sire age on precocious maturation rate was observed. Exploratory analyses investigating additional effects of egg size, dam length, and spawn date also failed to identify consistent predictors of precocious maturation. Instead, variability was largely attributed to both dam- and sire-specific effects, indicating a heritable component to precocious maturation, though not detectably associated with other measured attributes.</p>
 </ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code.svg" height="15"/>
+</picture>
 <strong>
 <em>CODE/DATA</em>
 </strong>
@@ -595,8 +682,11 @@ Not Available
 </a>
 </ul>
 <p></p>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment.svg" height="15"/>
+</picture>
 <strong>
 <em>CITATIONS</em>
 </strong>
@@ -621,8 +711,11 @@ Not Available
 </summary>
 <p></p>
 <ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book.svg" height="15"/>
+</picture>
 <strong>
 <em>JOURNAL</em>
 </strong>
@@ -636,24 +729,33 @@ Not Available
 </a>
 </p>
 </ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users.svg" height="15"/>
+</picture>
 <strong>
 <em>AUTHORS</em>
 </strong>
 <ul>
 <p>Staton, B. A., M. J. Catalano, S. J. Fleischman, and J. Ohlberger</p>
 </ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg" height="15"/>
+</picture>
 <strong>
 <em>ABSTRACT</em>
 </strong>
 <ul>
 <p align="justify">Changes over time in age, sex, and length-at-age of returning Pacific salmon have been widely observed, suggesting concurrent declines in per capita reproductive output. Thus, assessment models assuming stationary reproductive output may inaccurately estimate biological reference points that inform harvest policies. We extended age-structured state-space spawner&#8211;recruit models to accommodate demographic time trends and fishery selectivity to investigate temporal changes in reference points using Kuskokwim River Chinook salmon (<em>Oncorhynchus tshawytscha</em>). We illustrate that observed demographic changes have likely reduced per capita reproductive output in an additive manner, for example, models including changes in both length-at-age and age composition showed larger declines than models incorporating only one time trend. Translated into biological reference points using a yield-per-recruit algorithm, we found escapement needed for maximum sustained catch has likely increased over time, but the magnitude further depended on size-selective harvest (i.e., larger increases for reference points based on larger mesh gillnets). Compared to traditional salmon assessments, our approach that acknowledges demographic time trends allows more complete use of available data and facilitates evaluating trade-offs among gear-specific harvest policies.</p>
 </ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code.svg" height="15"/>
+</picture>
 <strong>
 <em>CODE/DATA</em>
 </strong>
@@ -667,8 +769,11 @@ Not Available
 </a>
 </ul>
 <p></p>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment.svg" height="15"/>
+</picture>
 <strong>
 <em>CITATIONS</em>
 </strong>
@@ -693,8 +798,11 @@ Not Available
 </summary>
 <p></p>
 <ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book.svg" height="15"/>
+</picture>
 <strong>
 <em>JOURNAL</em>
 </strong>
@@ -708,24 +816,33 @@ Not Available
 </a>
 </p>
 </ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users.svg" height="15"/>
+</picture>
 <strong>
 <em>AUTHORS</em>
 </strong>
 <ul>
 <p>Kaylor, M. J., C. Justice, J. B. Armstrong, <strong>B. A. Staton</strong>, L. A. Burns, E. Sedell, and S. M. White</p>
 </ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg" height="15"/>
+</picture>
 <strong>
 <em>ABSTRACT</em>
 </strong>
 <ul>
 <p align="justify">(1) Changes in biophysical conditions through time generate spatial and temporal variability in habitat quality across landscapes. For river ecosystems, researchers are increasingly able to characterize spatial and temporal patterns in habitat conditions, referred to as shifting habitat mosaics, yet rarely demonstrate how this translates into corresponding biological processes such as organism growth and production. (2) We assessed spatial patterns and processes determining seasonal changes in juvenile Chinook Salmon <em>Oncorhynchus tshawytscha</em> size, growth and production over 30&#8211;40 km in two NE Oregon subbasins. (3) We quantified seasonal patterns of growth by combining estimated emergence dates and body size distributions in July and September. We then used analysis of bioenergetics, empirical fish diets and spatial models incorporating temperature, habitat and population density to evaluate mechanisms driving spatiotemporal patterns of growth. Lastly, we quantified seasonal contributions to individual fish growth and to total production as a function of position within the stream network. (4) Spatial heterogeneity in incubation temperatures corresponded to later estimated emergence timing with distance upstream in both subbasins. During spring, estimated growth rates decreased with distance upstream, and coupled with emergence patterns, resulted in pronounced longitudinal gradients in body size by July. During summer, spatial patterns of growth reversed, with greater diet ration sizes and growth efficiencies upstream than downstream. These opposing spatiotemporal patterns of emergence timing and seasonal growth rates produced longitudinal gradients in the proportion of fish growth achieved in spring versus summer, with up to 80% of an individual's growth occurring in spring at downstream sites but as low as 10% at upstream sites. Coupling longitudinal patterns of fish density and growth revealed that in one subbasin the majority (65%) of total production occurred in spring, while in the other, in which fish were concentrated in headwaters, the majority (60%) of production occurred in summer. (5) While recent work has emphasized inter-annual shifts in fish production across large spatial scales, this study demonstrates that longitudinal gradients of fish growth and production can reverse across seasons, and reveals important contributions of warmer, downstream habitats to overall production that occurred during cooler times of the year.</p>
 </ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code.svg" height="15"/>
+</picture>
 <strong>
 <em>CODE/DATA</em>
 </strong>
@@ -739,8 +856,11 @@ Not Available
 </a>
 </ul>
 <p></p>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment.svg" height="15"/>
+</picture>
 <strong>
 <em>CITATIONS</em>
 </strong>
@@ -768,8 +888,11 @@ Not Available
 </summary>
 <p></p>
 <ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book.svg" height="15"/>
+</picture>
 <strong>
 <em>JOURNAL</em>
 </strong>
@@ -783,24 +906,33 @@ Not Available
 </a>
 </p>
 </ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users.svg" height="15"/>
+</picture>
 <strong>
 <em>AUTHORS</em>
 </strong>
 <ul>
 <p>Staton, B. A., M. J. Catalano, B. M. Connors, L. G. C. Jr, M. L. Jones, C. J. Walters, S. J. Fleischman, and D. C. Gwinn</p>
 </ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg" height="15"/>
+</picture>
 <strong>
 <em>ABSTRACT</em>
 </strong>
 <ul>
 <p align="justify">Salmon populations harvested in mixed-stock fisheries can exhibit genotypic, behavioral, and life history diversity that can lead to heterogeneity in population productivity and size. Methods to quantify this heterogeneity among populations in mixed-stock fisheries are not well-established but are critical to assessing harvest&#8211;biodiversity trade-offs when setting harvest policies. We developed an integrated, age-structured, state-space model that allows for more complete use of available data and sharing of information than simpler methods. We compared a suite of state-space models of varying structural complexity to simpler regression-based approaches and, as an example case, fitted them to data from 13 Chinook salmon (<em>Oncorhynchus tshawytscha</em>) populations in the Kuskokwim drainage in western Alaska. We found biological and policy conclusions were largely consistent among state-space models but differed strongly from regression-based approaches. Simulation trials illustrated our state-space models were largely unbiased with respect to spawner&#8211;recruit parameters, abundance states, and derived biological reference points, whereas the regression-based approaches showed substantial bias. These findings suggest our state-space model shows promise for informing harvest policy evaluations of harvest&#8211;biodiversity trade-offs in mixed-stock salmon fisheries.</p>
 </ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code.svg" height="15"/>
+</picture>
 <strong>
 <em>CODE/DATA</em>
 </strong>
@@ -814,8 +946,11 @@ Not Available
 </a>
 </ul>
 <p></p>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment.svg" height="15"/>
+</picture>
 <strong>
 <em>CITATIONS</em>
 </strong>
@@ -840,8 +975,11 @@ Not Available
 </summary>
 <p></p>
 <ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book.svg" height="15"/>
+</picture>
 <strong>
 <em>JOURNAL</em>
 </strong>
@@ -855,24 +993,33 @@ Not Available
 </a>
 </p>
 </ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users.svg" height="15"/>
+</picture>
 <strong>
 <em>AUTHORS</em>
 </strong>
 <ul>
 <p>Connors, B. M., <strong>B. Staton</strong>, L. Coggins, C. Walters, M. Jones, D. Gwinn, M. Catalano, and S. Fleischman</p>
 </ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg" height="15"/>
+</picture>
 <strong>
 <em>ABSTRACT</em>
 </strong>
 <ul>
 <p align="justify">Accounting for population diversity can be critical to the sustainable management of mixed-stock fisheries because harvest rates that can be sustained by productive populations may come at the cost of overfishing less productive ones. While these harvest&#8211;diversity trade-offs are well-recognized, their consequences for harvest policy performance are not often explicitly evaluated in contemporary fisheries management. We use closed-loop simulations to evaluate the ability of alternative harvest policies to meet population diversity and fishery objectives for one of the largest subsistence Chinook salmon (<em>Oncorhynchus tshawytscha</em>) fisheries in the world (Kuskokwim River Basin in western Alaska). We found clear evidence of population diversity that resulted in asymmetric trade-offs among fishery and conservation objectives whereby policies that forgo relatively small amounts of harvest result in relatively large increases in equitable access to Chinook and elimination of risk of weak stock extirpation. The performance of alternative harvest policies, and the magnitude of trade-offs, were sensitive to regime shifts and uncertainty in the drivers of recruitment variation. However, we found that harvest policies that prioritized meeting minimum subsistence needs were unlikely to jeopardize long-term sustainability.</p>
 </ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code.svg" height="15"/>
+</picture>
 <strong>
 <em>CODE/DATA</em>
 </strong>
@@ -886,8 +1033,11 @@ Not Available
 </a>
 </ul>
 <p></p>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment.svg" height="15"/>
+</picture>
 <strong>
 <em>CITATIONS</em>
 </strong>
@@ -915,8 +1065,11 @@ Not Available
 </summary>
 <p></p>
 <ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book.svg" height="15"/>
+</picture>
 <strong>
 <em>JOURNAL</em>
 </strong>
@@ -930,24 +1083,33 @@ Not Available
 </a>
 </p>
 </ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users.svg" height="15"/>
+</picture>
 <strong>
 <em>AUTHORS</em>
 </strong>
 <ul>
 <p>Staton, B. A. and M. J. Catalano</p>
 </ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg" height="15"/>
+</picture>
 <strong>
 <em>ABSTRACT</em>
 </strong>
 <ul>
 <p align="justify">Preseason forecasts of Pacific salmon run size are notoriously uncertain and are thus often updated using various abundance indices collected during the run. However, interpretation of these in-season indices is confounded by uncertainty in migration timing. We assessed the performance of two Bayesian information-updating procedures for Kuskokwim River Chinook salmon (<em>Oncorhynchus tshawytscha</em>), one that uses auxiliary run timing information and one that does not, and compared the performance with methods that did not involve updating. We found that in-season Bayesian updating provided more accurate run size estimates during the time when harvest decisions needed to be made, but that the incorporation of run timing forecasts had little utility in terms of providing more accurate run size estimates. The latter finding is conditional on the performance of the run timing forecast model we used; a more accurate timing forecast model might yield a different conclusion. The Bayesian approach we developed provided a probabilistic expression of run size beliefs, which could be useful in a transparent risk-assessment framework for setting and altering harvest targets during the season.</p>
 </ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code.svg" height="15"/>
+</picture>
 <strong>
 <em>CODE/DATA</em>
 </strong>
@@ -961,8 +1123,11 @@ Not Available
 </a>
 </ul>
 <p></p>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment.svg" height="15"/>
+</picture>
 <strong>
 <em>CITATIONS</em>
 </strong>
@@ -987,8 +1152,11 @@ Not Available
 </summary>
 <p></p>
 <ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book.svg" height="15"/>
+</picture>
 <strong>
 <em>JOURNAL</em>
 </strong>
@@ -1002,24 +1170,33 @@ Not Available
 </a>
 </p>
 </ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users.svg" height="15"/>
+</picture>
 <strong>
 <em>AUTHORS</em>
 </strong>
 <ul>
 <p>Moses, A. P., <strong>B. A. Staton</strong>, and N. J. Smith</p>
 </ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg" height="15"/>
+</picture>
 <strong>
 <em>ABSTRACT</em>
 </strong>
 <ul>
 <p align="justify">Detailed information regarding migratory behavior (i.e., phenology and rate of travel) of specific Pacific salmon Oncorhynchus spp. substocks can be used to design management strategies focused on protecting substocks from harvest when desired; however, this information is often lacking. The Kwethluk and Kisaralik rivers are two tributaries of the lower Kuskokwim River that originate and flow through the Yukon Delta National Wildlife Refuge in western Alaska. Although these two systems are the primary Chinook Salmon&#8211;producing tributaries within the Yukon Delta National Wildlife Refuge, little is known about migratory behavior of Chinook Salmon destined for these rivers. In 2015 and 2016, 119 Chinook Salmon tagged with radio telemetry transmitters entered either the Kwethluk or Kisaralik Rivers and were tracked throughout their migration to their assumed final spawning location using both ground- and aerial-based tracking methods. We compared migration timing and swim speeds between fish bound for these two rivers and between fish of different sizes and compared the consistency among the 2 y. In general, we found that fish bound for the Kwethluk and Kisaralik rivers exhibited similar migration behaviors in 2015 and 2016, including entry timing into the Kuskokwim River and migration rates once in the tributaries. A key finding was that Chinook Salmon swam fastest (range of means between years: 20&#8211;45 km/d) in the main-stem Kuskokwim River and slowed significantly (4&#8211;15 km/d) upon entry into lower portions of the tributaries. Our findings have relevance for harvest management strategies; for example, temporal fishery closures will impact Chinook Salmon bound for both the Kwethluk and Kisaralik rivers equally given their broad overlap in entry timing, and individuals will remain vulnerable to harvest for longer periods when located in tributaries rather than the portion of the main-stem directly below the tributary confluences.</p>
 </ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code.svg" height="15"/>
+</picture>
 <strong>
 <em>CODE/DATA</em>
 </strong>
@@ -1033,8 +1210,11 @@ Not Available
 </a>
 </ul>
 <p></p>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment.svg" height="15"/>
+</picture>
 <strong>
 <em>CITATIONS</em>
 </strong>
@@ -1062,8 +1242,11 @@ Not Available
 </summary>
 <p></p>
 <ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book.svg" height="15"/>
+</picture>
 <strong>
 <em>JOURNAL</em>
 </strong>
@@ -1077,24 +1260,33 @@ Not Available
 </a>
 </p>
 </ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users.svg" height="15"/>
+</picture>
 <strong>
 <em>AUTHORS</em>
 </strong>
 <ul>
 <p>Staton, B. A., M. J. Catalano, T. M. Farmer, A. Abebe, and F. S. Dobson</p>
 </ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg" height="15"/>
+</picture>
 <strong>
 <em>ABSTRACT</em>
 </strong>
 <ul>
 <p align="justify">Annual variation in adult salmon migration timing makes the interpretation of in-season assessment data difficult, leading to much in-season uncertainty in run size. We developed and evaluated a run timing forecast model for the Kuskokwim River Chinook salmon stock, located in western Alaska, intended to aid in reducing this source of uncertainty. An objective and adaptive approach (using model-averaging and a sliding window algorithm to select predictive time periods, both calibrated annually) was adopted to deal with multidimensional selection of four climatic variables and was based entirely on predictive performance. Forecast cross-validation was used to evaluate the performance of three forecasting approaches: the null (i.e., intercept only) model, the single model with the lowest mean absolute error, and a model-averaged forecast across 16 nested linear models. As of 2016, the null model had the lowest mean absolute error (2.64 days), although the model-averaged forecast performed as well or better than the null model in the majority of retrospective years. The model-averaged forecast had a consistent mean absolute error regardless of the type of year (i.e., average or extreme early/late) the forecast was made for, which was not true of the null model. The availability of the run timing forecast was not found to increase overall accuracy of in-season run assessments in relation to the null model, but was found to substantially increase the precision of these assessments, particularly early in the season.</p>
 </ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code.svg" height="15"/>
+</picture>
 <strong>
 <em>CODE/DATA</em>
 </strong>
@@ -1106,8 +1298,11 @@ Not Available
 Not Available
 </ul>
 <p></p>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment.svg" height="15"/>
+</picture>
 <strong>
 <em>CITATIONS</em>
 </strong>
@@ -1132,8 +1327,11 @@ Not Available
 </summary>
 <p></p>
 <ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book.svg" height="15"/>
+</picture>
 <strong>
 <em>JOURNAL</em>
 </strong>
@@ -1147,24 +1345,33 @@ Not Available
 </a>
 </p>
 </ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users.svg" height="15"/>
+</picture>
 <strong>
 <em>AUTHORS</em>
 </strong>
 <ul>
 <p>Dippold, D. A., G. D. Adams, T. M. Farmer, and <strong>B. A. Staton</strong></p>
 </ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg" height="15"/>
+</picture>
 <strong>
 <em>ABSTRACT</em>
 </strong>
 <ul>
 <p align="justify">No applicable abstract.</p>
 </ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code.svg" height="15"/>
+</picture>
 <strong>
 <em>CODE/DATA</em>
 </strong>
@@ -1176,8 +1383,11 @@ Not Available
 Not Available
 </ul>
 <p></p>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment.svg" height="15"/>
+</picture>
 <strong>
 <em>CITATIONS</em>
 </strong>
@@ -1202,8 +1412,11 @@ Not Available
 </summary>
 <p></p>
 <ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book.svg" height="15"/>
+</picture>
 <strong>
 <em>JOURNAL</em>
 </strong>
@@ -1214,24 +1427,33 @@ Not Available
 <br/>
 </p>
 </ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users.svg" height="15"/>
+</picture>
 <strong>
 <em>AUTHORS</em>
 </strong>
 <ul>
 <p>White, L., M. Meade, and <strong>B. Staton</strong></p>
 </ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg" height="15"/>
+</picture>
 <strong>
 <em>ABSTRACT</em>
 </strong>
 <ul>
 <p align="justify">The occurrence of Asiatic Weatherfish, <em>Misgurnus anguillicaudatus</em>, in Alabama, a state known for its rich biodiversity, has generated concern among conservation managers. The current study used respirometry techniques to investigate the effects of increasing temperature on four native southeastern fishes (one cyprinid, two percids, and one elassomid) and the non-native <em>M. anguillicaudatus</em>. A minimum of five individuals of each species were used, and three experimental temperatures were chosen to represent spring and summer averages of northeast Alabama streams (15, 20, and 25&#176;C). Overall, mean standard metabolic rates (SMRs) for <em>M. anguillicaudatus</em> were low (97.01, 127.75, and 158.50 mg O<sub>2</sub> kg<sup>-1</sup>h<sup>-1</sup> at 15, 20, and 25&#176;C, respectively); <em>M. anguillicaudatus</em> was the only species for which SMR did not significantly increase with temperature (p = 0.467). In contrast, mean SMRs for all native species examined were higher than <em>M. anguillicaudatus</em> rates at a given temperature, and mean SMRs for <em>Cyprinella caerulea</em>, <em>Etheostoma brevirostrum</em>, and <em>Etheostoma ditrema</em> exhibited significant increases in SMR when temperatures were increased (e.g. 403.46, 704.42, and 1150.03 mg O<sub>2</sub> kg<sup>-1</sup>h<sup>-1</sup> at 25&#176;C, respectively) (p &#60; 0.01). <em>Elassoma zonatum</em> displayed highly significant increases in SMR when temperature increased from 15-20&#176;C (p &#60; 0.001). Overall, the abiotic tolerances of <em>M. anguillicaudatus</em> may facilitate further establishment that could lead to negative impacts on native species.</p>
 </ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code.svg" height="15"/>
+</picture>
 <strong>
 <em>CODE/DATA</em>
 </strong>
@@ -1243,8 +1465,11 @@ Not Available
 Not Available
 </ul>
 <p></p>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment.svg" height="15"/>
+</picture>
 <strong>
 <em>CITATIONS</em>
 </strong>
@@ -1269,8 +1494,11 @@ NA
 </summary>
 <p></p>
 <ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book.svg" height="15"/>
+</picture>
 <strong>
 <em>JOURNAL</em>
 </strong>
@@ -1284,24 +1512,33 @@ NA
 </a>
 </p>
 </ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/users.svg" height="15"/>
+</picture>
 <strong>
 <em>AUTHORS</em>
 </strong>
 <ul>
 <p>Staton, B. A., M. J. Catalano, and S. J. Fleischman</p>
 </ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/book-reader.svg" height="15"/>
+</picture>
 <strong>
 <em>ABSTRACT</em>
 </strong>
 <ul>
 <p align="justify">Stock assessment scientists are faced with decisions regarding how to incorporate fishery information into models. One primary decision revolves around how estimates that are summaries of raw data should be treated (e.g., abundance estimates derived from relative indices). The choice in this case is to either use estimates from a sequence of models as data in a final model (i.e., the model used for setting management goals) or to integrate the raw data into a more complex final model. Each approach has advantages and disadvantages that constitute a suite of trade-offs. These trade-offs are investigated here by comparing two sequential analyses (one that ignores measurement error and one that incorporates it) to an integrated analysis for a stock assessment of Pacific salmon using simulation-estimation, and the Kuskokwim River Chinook salmon stock of western Alaska as a case study. The major difference between approaches was that an abundance reconstruction was estimated separately from the spawner-recruit analysis in the sequential approaches, whereas the integrated approach did so in a single model. Primary findings showed that approaches that addressed the measurement error in the raw data returned very similar estimates of abundance, population dynamics parameters, and management reference points, both in terms of point estimates and uncertainty. When measurement error was ignored, similar point estimates were returned. However, this approach underestimated uncertainty in the spawner-recruit analysis but resulted in more uncertainty in the abundance reconstruction. These findings were consistent for both the Kuskokwim River case study and simulation-estimation analyses. The primary advantage of the integrated analysis was the added realism of sharing calendar year abundance data among brood years, but came at the cost of slow model run times. This exercise showed that while there is a trade-off between sequential and integrated analyses in terms of model complexity and realism, the benefits may not be large enough to warrant an integrated analysis in all cases, given that the terminal model carries forward uncertainty in the input estimates.</p>
 </ul>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/code.svg" height="15"/>
+</picture>
 <strong>
 <em>CODE/DATA</em>
 </strong>
@@ -1313,8 +1550,11 @@ Not Available
 Not Available
 </ul>
 <p></p>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment.svg#gh-light-mode-only" height="15"/>
-<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment-dark.svg#gh-dark-mode-only" height="15"/>
+<picture>
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment.svg"/>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment-dark.svg"/>
+<img src="https://raw.githubusercontent.com/bstaton1/bstaton1/master/assets/comment.svg" height="15"/>
+</picture>
 <strong>
 <em>CITATIONS</em>
 </strong>
@@ -1327,6 +1567,367 @@ Not Available
 </ul>
 </ul>
 <hr/>
+</details>
+
+## Citations
+
+*This section contains summaries of citations made on research articles
+I’ve (co)authored; Google Scholar includes citations made in grey
+literature (e.g., agency reports) as well as from the peer-reviewed
+literature, whereas CrossRef indexes the latter only. Citation numbers
+differ here from those presented on [Google
+Scholar](https://scholar.google.com/citations?user=kembVusAAAAJ&hl=en)
+because those counts also include citations of grey literature I’ve
+(co)authored.*
+
+### Lead Author Articles
+
+<details>
+<summary>
+Click to View
+</summary>
+<table class="table" style="width: auto !important; margin-left: auto; margin-right: auto;">
+<thead>
+<tr>
+<th style="border-bottom:hidden;padding-bottom:0; padding-left:3px;padding-right:3px;text-align: center; " colspan="2">
+
+<div style="border-bottom: 1px solid #ddd; padding-bottom: 5px; ">
+
+Published
+
+</div>
+
+</th>
+<th style="border-bottom:hidden;padding-bottom:0; padding-left:3px;padding-right:3px;text-align: center; " colspan="2">
+
+<div style="border-bottom: 1px solid #ddd; padding-bottom: 5px; ">
+
+Cumulative Citations
+
+</div>
+
+</th>
+</tr>
+<tr>
+<th style="text-align:left;">
+Year
+</th>
+<th style="text-align:center;">
+Articles
+</th>
+<th style="text-align:center;">
+CrossRef
+</th>
+<th style="text-align:center;">
+Google Scholar
+</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="text-align:left;font-weight: bold;">
+2017
+</td>
+<td style="text-align:center;">
+2
+</td>
+<td style="text-align:center;">
+15
+</td>
+<td style="text-align:center;">
+29
+</td>
+</tr>
+<tr>
+<td style="text-align:left;font-weight: bold;">
+2018
+</td>
+<td style="text-align:center;">
+0
+</td>
+<td style="text-align:center;">
+0
+</td>
+<td style="text-align:center;">
+0
+</td>
+</tr>
+<tr>
+<td style="text-align:left;font-weight: bold;">
+2019
+</td>
+<td style="text-align:center;">
+1
+</td>
+<td style="text-align:center;">
+4
+</td>
+<td style="text-align:center;">
+9
+</td>
+</tr>
+<tr>
+<td style="text-align:left;font-weight: bold;">
+2020
+</td>
+<td style="text-align:center;">
+1
+</td>
+<td style="text-align:center;">
+8
+</td>
+<td style="text-align:center;">
+8
+</td>
+</tr>
+<tr>
+<td style="text-align:left;font-weight: bold;">
+2021
+</td>
+<td style="text-align:center;">
+1
+</td>
+<td style="text-align:center;">
+6
+</td>
+<td style="text-align:center;">
+8
+</td>
+</tr>
+<tr>
+<td style="text-align:left;font-weight: bold;">
+2022
+</td>
+<td style="text-align:center;">
+1
+</td>
+<td style="text-align:center;">
+3
+</td>
+<td style="text-align:center;">
+3
+</td>
+</tr>
+<tr>
+<td style="text-align:left;font-weight: bold;font-weight: bold;">
+All
+</td>
+<td style="text-align:center;font-weight: bold;">
+6
+</td>
+<td style="text-align:center;font-weight: bold;">
+36
+</td>
+<td style="text-align:center;font-weight: bold;">
+57
+</td>
+</tr>
+</tbody>
+</table>
+<table>
+<thead>
+<tr>
+<th style="text-align:left;">
+</th>
+<th style="text-align:right;">
+h-index
+</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="text-align:left;font-weight: bold;">
+CrossRef
+</td>
+<td style="text-align:right;">
+4
+</td>
+</tr>
+<tr>
+<td style="text-align:left;font-weight: bold;">
+Google Scholar
+</td>
+<td style="text-align:right;">
+5
+</td>
+</tr>
+</tbody>
+</table>
+</details>
+
+### All Articles
+
+<details>
+<summary>
+Click to View
+</summary>
+<table class="table" style="width: auto !important; margin-left: auto; margin-right: auto;">
+<thead>
+<tr>
+<th style="border-bottom:hidden;padding-bottom:0; padding-left:3px;padding-right:3px;text-align: center; " colspan="2">
+
+<div style="border-bottom: 1px solid #ddd; padding-bottom: 5px; ">
+
+Published
+
+</div>
+
+</th>
+<th style="border-bottom:hidden;padding-bottom:0; padding-left:3px;padding-right:3px;text-align: center; " colspan="2">
+
+<div style="border-bottom: 1px solid #ddd; padding-bottom: 5px; ">
+
+Cumulative Citations
+
+</div>
+
+</th>
+</tr>
+<tr>
+<th style="text-align:left;">
+Year
+</th>
+<th style="text-align:center;">
+Articles
+</th>
+<th style="text-align:center;">
+CrossRef
+</th>
+<th style="text-align:center;">
+Google Scholar
+</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="text-align:left;font-weight: bold;">
+2017
+</td>
+<td style="text-align:center;">
+4
+</td>
+<td style="text-align:center;">
+15
+</td>
+<td style="text-align:center;">
+30
+</td>
+</tr>
+<tr>
+<td style="text-align:left;font-weight: bold;">
+2018
+</td>
+<td style="text-align:center;">
+0
+</td>
+<td style="text-align:center;">
+0
+</td>
+<td style="text-align:center;">
+0
+</td>
+</tr>
+<tr>
+<td style="text-align:left;font-weight: bold;">
+2019
+</td>
+<td style="text-align:center;">
+2
+</td>
+<td style="text-align:center;">
+4
+</td>
+<td style="text-align:center;">
+11
+</td>
+</tr>
+<tr>
+<td style="text-align:left;font-weight: bold;">
+2020
+</td>
+<td style="text-align:center;">
+2
+</td>
+<td style="text-align:center;">
+19
+</td>
+<td style="text-align:center;">
+21
+</td>
+</tr>
+<tr>
+<td style="text-align:left;font-weight: bold;">
+2021
+</td>
+<td style="text-align:center;">
+3
+</td>
+<td style="text-align:center;">
+14
+</td>
+<td style="text-align:center;">
+20
+</td>
+</tr>
+<tr>
+<td style="text-align:left;font-weight: bold;">
+2022
+</td>
+<td style="text-align:center;">
+5
+</td>
+<td style="text-align:center;">
+12
+</td>
+<td style="text-align:center;">
+12
+</td>
+</tr>
+<tr>
+<td style="text-align:left;font-weight: bold;font-weight: bold;">
+All
+</td>
+<td style="text-align:center;font-weight: bold;">
+16
+</td>
+<td style="text-align:center;font-weight: bold;">
+64
+</td>
+<td style="text-align:center;font-weight: bold;">
+94
+</td>
+</tr>
+</tbody>
+</table>
+<table>
+<thead>
+<tr>
+<th style="text-align:left;">
+</th>
+<th style="text-align:right;">
+h-index
+</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="text-align:left;font-weight: bold;">
+CrossRef
+</td>
+<td style="text-align:right;">
+6
+</td>
+</tr>
+<tr>
+<td style="text-align:left;font-weight: bold;">
+Google Scholar
+</td>
+<td style="text-align:right;">
+7
+</td>
+</tr>
+</tbody>
+</table>
 </details>
 <p align="center">
 <sub>
@@ -1362,7 +1963,7 @@ Ben Staton under the
 <sup>
 <em>
 Updated
-2023-06-28
+2023-06-30
 </em>
 </sup>
 </sub>


### PR DESCRIPTION
This PR closes #5 by updating the code that tells GitHub to display the correct icons based on whether the user has a dark or light theme selected. It also introduces a new section that summarizes citation counts.